### PR TITLE
Simplifying API by adding kw args ndims and align to some key functions

### DIFF
--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -185,7 +185,11 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # align data
     if align:
-        x = aligner(x)
+        if len(data) == 1:
+            warn('Data in list of length 1 can not be aligned. '
+                 'Skipping the alignment.')
+        else:
+            data = aligner(data)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -185,11 +185,11 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # align data
     if align:
-        if len(data) == 1:
+        if len(x) == 1:
             warn('Data in list of length 1 can not be aligned. '
                  'Skipping the alignment.')
         else:
-            data = aligner(data)
+            x = aligner(x)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -25,7 +25,7 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
          align=False, normalize=False, n_clusters=None, save_path=None,
          animate=False, duration=30, tail_duration=2, rotations=2, zoom=1,
          chemtrails=False, precog=False, bullettime=False, frame_rate=50,
-         explore=False, show=True, ):
+         explore=False, show=True):
     """
     Plots dimensionality reduced data and parses plot arguments
 

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -10,7 +10,6 @@ import seaborn as sns
 import pandas as pd
 from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
-import matplotlib.animation as animation
 from .._shared.helpers import *
 from ..tools.cluster import cluster
 from ..tools.df2mat import df2mat
@@ -60,9 +59,9 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         A list of labels for each point. Must be dimensionality of data (x).
         If no label is wanted for a particular point, input None.
 
-    legend : list or bool
-        If set to True, legend is implicitly computed from data. Passing a
-        list will add string labels to the legend (one for each list item).
+    legend : list
+        A list of string labels to be plotted in a legend (one for each list
+        item).
 
     title : str
         A title for the plot
@@ -176,6 +175,10 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
             warnings.warn('Both marker and markers defined: marker will be \
                           ignored in favor of markers.')
 
+    # handle legend
+    if legend is not None:
+        mpl_kwargs['label'] = legend
+
     # normalize
     x = normalizer(x, normalize=normalize, internal=True)
 
@@ -185,7 +188,11 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # align data
     if align:
-        x = aligner(x)
+        if len(data) == 1:
+            warn('Data in list of length 1 can not be aligned. '
+                 'Skipping the alignment.')
+        else:
+            x = aligner(x)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:
@@ -216,17 +223,6 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         # interpolate lines if they are grouped
         if is_line(fmt):
             x = patch_lines(x)
-
-    # handle legend
-    if legend is not None:
-        if legend is False:
-            legend = None
-        elif legend is True and group is not None:
-            legend = [item for item in sorted(set(group), key=list(group).index)]
-        elif legend is True and group is None:
-            legend = [i + 1 for i in range(len(x))]
-
-        mpl_kwargs['label'] = legend
 
     # interpolate if its a line plot
     if fmt is None or type(fmt) is str:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -10,6 +10,7 @@ import seaborn as sns
 import pandas as pd
 from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
+import matplotlib.animation as animation
 from .._shared.helpers import *
 from ..tools.cluster import cluster
 from ..tools.df2mat import df2mat
@@ -59,9 +60,9 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         A list of labels for each point. Must be dimensionality of data (x).
         If no label is wanted for a particular point, input None.
 
-    legend : list
-        A list of string labels to be plotted in a legend (one for each list
-        item).
+    legend : list or bool
+        If set to True, legend is implicitly computed from data. Passing a
+        list will add string labels to the legend (one for each list item).
 
     title : str
         A title for the plot
@@ -175,10 +176,6 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
             warnings.warn('Both marker and markers defined: marker will be \
                           ignored in favor of markers.')
 
-    # handle legend
-    if legend is not None:
-        mpl_kwargs['label'] = legend
-
     # normalize
     x = normalizer(x, normalize=normalize, internal=True)
 
@@ -188,11 +185,7 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # align data
     if align:
-        if len(data) == 1:
-            warn('Data in list of length 1 can not be aligned. '
-                 'Skipping the alignment.')
-        else:
-            x = aligner(x)
+        x = aligner(x)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:
@@ -223,6 +216,17 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         # interpolate lines if they are grouped
         if is_line(fmt):
             x = patch_lines(x)
+
+    # handle legend
+    if legend is not None:
+        if legend is False:
+            legend = None
+        elif legend is True and group is not None:
+            legend = [item for item in sorted(set(group), key=list(group).index)]
+        elif legend is True and group is None:
+            legend = [i + 1 for i in range(len(x))]
+
+        mpl_kwargs['label'] = legend
 
     # interpolate if its a line plot
     if fmt is None or type(fmt) is str:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -70,8 +70,10 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     ndims : int
         An `int` representing the number of dims to reduce the data x
         to. If ndims > 3, will plot in 3 dimensions but return the higher
-        dimensional data. Default is None, which will reduce data to 3
-        dimensions  and plot in 3 dimensions.
+        dimensional data. Default is None, which will plot data in 3
+        dimensions and return the data with the same number of dimensions
+        possibly normalized and/or aligned according to normalize/align
+        kwargs.
 
     align : bool
         If set to True, data will be run through the ``hyperalignment''
@@ -151,6 +153,9 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     # turn data into common format - a list of arrays
     x = format_data(x)
 
+    # normalize
+    x = normalizer(x, normalize=normalize, internal=True)
+
     # reduce data to ndims
     if ndims is not None:
         x = reduceD(x, ndims=ndims, internal=True)
@@ -162,8 +167,8 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
                  'Skipping the alignment.')
         else:
             x = aligner(x)
-    # This is what gets returned, unless ndim is None (see below)
-    reduced_and_aligned = x
+    # Return data that has been normalized and possibly reduced and/or aligned
+    return_data = x
 
     # catch all matplotlib kwargs here to pass on
     mpl_kwargs = {}
@@ -192,14 +197,9 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
             warnings.warn('Both marker and markers defined: marker will be \
                           ignored in favor of markers.')
 
-    # normalize
-    x = normalizer(x, normalize=normalize, internal=True)
-
     # reduce data to 3 dims for plotting, if ndims is None, return this
     if (ndims and ndims > 3) or (ndims is None and x[0].shape[1] > 3):
         x = reduceD(x, ndims=3, internal=True)
-        if ndims is None:
-            reduced_and_aligned = x
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:
@@ -312,4 +312,4 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     if show:
         plt.show()
 
-    return fig, ax, reduced_and_aligned, line_ani
+    return fig, ax, return_data, line_ani

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -60,9 +60,9 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         A list of labels for each point. Must be dimensionality of data (x).
         If no label is wanted for a particular point, input None.
 
-    legend : list
-        A list of string labels to be plotted in a legend (one for each list
-        item).
+    legend : list or bool
+        If set to True, legend is implicitly computed from data. Passing a
+        list will add string labels to the legend (one for each list item).
 
     title : str
         A title for the plot
@@ -192,10 +192,6 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
             warnings.warn('Both marker and markers defined: marker will be \
                           ignored in favor of markers.')
 
-    # handle legend
-    if legend is not None:
-        mpl_kwargs['label'] = legend
-
     # normalize
     x = normalizer(x, normalize=normalize, internal=True)
 
@@ -234,6 +230,17 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         # interpolate lines if they are grouped
         if is_line(fmt):
             x = patch_lines(x)
+
+    # handle legend
+    if legend is not None:
+        if legend is False:
+            legend = None
+        elif leged is True and group is not None:
+            legend = [item for item in sorted(set(group), key=list(group).index)]
+        elif legend is True and group is None:
+            legend = [i + 1 for i in range(len(x))]
+
+        mpl_kwargs['label'] = legend
 
     # interpolate if its a line plot
     if fmt is None or type(fmt) is str:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -16,15 +16,16 @@ from ..tools.cluster import cluster
 from ..tools.df2mat import df2mat
 from ..tools.reduce import reduce as reduceD
 from ..tools.normalize import normalize as normalizer
+from ..tools.align import align as aligner
 from .draw import draw
 
 def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
          linestyles=None, color=None, colors=None, palette='hls', group=None,
          labels=None, legend=None, title=None, elev=10, azim=-60, ndims=3,
-         normalize=False, n_clusters=None, save_path=None, animate=False,
-         duration=30, tail_duration=2, rotations=2, zoom=1, chemtrails=False,
-         precog=False, bullettime=False, frame_rate=50, explore=False,
-         show=True):
+         align=False, normalize=False, n_clusters=None, save_path=None,
+         animate=False, duration=30, tail_duration=2, rotations=2, zoom=1,
+         chemtrails=False, precog=False, bullettime=False, frame_rate=50,
+         explore=False, show=True, ):
     """
     Plots dimensionality reduced data and parses plot arguments
 
@@ -69,6 +70,10 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     ndims : int
         An `int` representing the number of dims to plot in. Must be 1,2, or 3.
         NOTE: Currently only works with static plots.
+
+    align : bool
+        If set to True, data will be run through the ``hyperalignment''
+        algorithm implemented in hypertools.tools.align (default: False).
 
     normalize : str or False
         If set to 'across', the columns of the input data will be z-scored
@@ -177,6 +182,10 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     # reduce data
     if x[0].shape[1]>3:
         x = reduceD(x, ndims, internal=True)
+
+    # align data
+    if align:
+        x = aligner(x)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -235,7 +235,7 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     if legend is not None:
         if legend is False:
             legend = None
-        elif leged is True and group is not None:
+        elif legend is True and group is not None:
             legend = [item for item in sorted(set(group), key=list(group).index)]
         elif legend is True and group is None:
             legend = [i + 1 for i in range(len(x))]

--- a/hypertools/tools/align.py
+++ b/hypertools/tools/align.py
@@ -26,7 +26,6 @@ from .procrustes import procrustes
 import numpy as np
 from .._shared.helpers import format_data
 from warnings import warn
-from .reduce import reduce as reduceD
 
 ##MAIN FUNCTION##
 def align(data, method='hyper', ndims=None):
@@ -75,7 +74,8 @@ def align(data, method='hyper', ndims=None):
 
     # reduce if ndims is specified
     if ndims is not None:
-        data = reduceD(data, ndims, internal=True)
+        from .reduce import reduce as reducer
+        data = reducer(data, ndims, internal=True)
 
     if method=='hyper':
 
@@ -85,7 +85,7 @@ def align(data, method='hyper', ndims=None):
 
         #find the smallest number of rows
         R = min(sizes_0)
-        C = max([3, max(sizes_1)])
+        C = max(sizes_1)
 
         m = [np.empty((R,C), dtype=np.ndarray)] * len(data)
 

--- a/hypertools/tools/align.py
+++ b/hypertools/tools/align.py
@@ -26,9 +26,10 @@ from .procrustes import procrustes
 import numpy as np
 from .._shared.helpers import format_data
 from warnings import warn
+from .reduce import reduce as reduceD
 
 ##MAIN FUNCTION##
-def align(data, method='hyper'):
+def align(data, method='hyper', ndims=None):
     """
     Aligns a list of arrays
 
@@ -55,6 +56,9 @@ def align(data, method='hyper'):
     method : str
         Either 'hyper' or 'SRM'.  If 'hyper' (default),
 
+    ndims : int
+        Number of dimensions to reduce the dataset to *prior* to alignment
+
     Returns
     ----------
     aligned : list
@@ -68,6 +72,10 @@ def align(data, method='hyper'):
         warn('The number of features exceeds number of samples. This can lead \
              to overfitting.  We recommend reducing the dimensionality to be \
              less than the number of samples prior to hyperalignment.')
+
+    # reduce if ndims is specified
+    if ndims is not None:
+        data = reduceD(data, ndims, internal=True)
 
     if method=='hyper':
 

--- a/hypertools/tools/align.py
+++ b/hypertools/tools/align.py
@@ -25,10 +25,11 @@ from .._externals.srm import SRM
 from .procrustes import procrustes
 import numpy as np
 from .._shared.helpers import format_data
+from .normalize import normalize as normalizer
 from warnings import warn
 
 ##MAIN FUNCTION##
-def align(data, method='hyper', ndims=None):
+def align(data, method='hyper', normalize=False, ndims=None):
     """
     Aligns a list of arrays
 
@@ -55,6 +56,13 @@ def align(data, method='hyper', ndims=None):
     method : str
         Either 'hyper' or 'SRM'.  If 'hyper' (default),
 
+    normalize : str or False
+        If set to 'across', the columns of the input data will be z-scored
+        across lists (default). If set to 'within', the columns will be
+        z-scored within each list that is passed. If set to 'row', each row of
+        the input data will be z-scored. If set to False, the input data will
+        be returned (default is False).
+
     ndims : int
         Number of dimensions to reduce the dataset to *prior* to alignment
 
@@ -72,8 +80,13 @@ def align(data, method='hyper', ndims=None):
              to overfitting.  We recommend reducing the dimensionality to be \
              less than the number of samples prior to hyperalignment.')
 
+    # normalize data
+    if normalize:
+        x = normalizer(x, normalize=normalize)
+
     # reduce if ndims is specified
     if ndims is not None:
+        # Import is here to avoid circular imports with align.py        
         from .reduce import reduce as reducer
         data = reducer(data, ndims, internal=True)
 

--- a/hypertools/tools/load.py
+++ b/hypertools/tools/load.py
@@ -2,8 +2,12 @@ import requests
 import pickle
 import pandas as pd
 import sys
+from warnings import warn
 
-def load(dataset):
+from .reduce import reduce as reduceD
+from .align import align as aligner
+
+def load(dataset, ndims=None, align=False):
     """
     Load example data
 
@@ -22,6 +26,12 @@ def load(dataset):
     ----------
     data : Numpy Array
         Example data
+
+    ndims : int
+        If not None, reduce data to ndims dimensions
+
+    align : bool
+        If True, run data through alignment algorithm in tools.alignment
 
     """
     if sys.version_info[0]==3:
@@ -51,5 +61,14 @@ def load(dataset):
         fileid = '0B7Ycm4aSYdPPY3J0U2tRNFB4T3c'
         url = 'https://docs.google.com/uc?export=download&id=' + fileid
         data = pd.read_csv(url)
+
+    if ndims is not None:
+        data = reduceD(data, ndims, internal=True)
+    if align:
+        if len(data) == 1:
+            warn('Data in list of length 1 can not be aligned. '
+                 'Skipping the alignment.')
+        else:
+            data = aligner(data)
 
     return data

--- a/hypertools/tools/procrustes.py
+++ b/hypertools/tools/procrustes.py
@@ -6,8 +6,12 @@ from builtins import zip
 from builtins import range
 import numpy as np
 
+from .reduce import reduce as reduceD
+
+
 ##MAIN FUNCTION##
-def procrustes(source, target, scaling=True, reflection=True, reduction=False, oblique=False, oblique_rcond=-1):
+def procrustes(source, target, scaling=True, reflection=True, reduction=False,
+               oblique=False, oblique_rcond=-1, ndims=None):
     """
     Function to project from one space to another using Procrustean
     transformation (shift + scaling + rotation + reflection).
@@ -48,6 +52,9 @@ def procrustes(source, target, scaling=True, reflection=True, reduction=False, o
         Cutoff for 'small' singular values to regularize the
         inverse. See :class:`~numpy.linalg.lstsq` for more
         information.
+
+    ndims : int
+        Number of dimensions to reduce the dataset to *prior* to alignment
 
     Returns
     ----------
@@ -188,5 +195,10 @@ def procrustes(source, target, scaling=True, reflection=True, reduction=False, o
 
         return res
 
+    # reduce if ndims is specified
+    if ndims is not None:
+        source = reduceD(source, ndims, internal=True)
+
+    # Fit and transform
     proj = fit(source, target)
     return transform(source, proj)

--- a/hypertools/tools/procrustes.py
+++ b/hypertools/tools/procrustes.py
@@ -5,15 +5,14 @@ from __future__ import division
 from builtins import zip
 from builtins import range
 import numpy as np
-
+from .normalize import normalize as normalizer
 from .reduce import reduce as reduceD
 
 
 ##MAIN FUNCTION##
 def procrustes(source, target, scaling=True, reflection=True, reduction=False,
-               oblique=False, oblique_rcond=-1, ndims=None):
-    """
-    Function to project from one space to another using Procrustean
+               oblique=False, oblique_rcond=-1, normalize=False, ndims=None):
+    """Function to project from one space to another using Procrustean
     transformation (shift + scaling + rotation + reflection).
 
     The implementation of this function was based on the ProcrusteanMapper in
@@ -52,6 +51,13 @@ def procrustes(source, target, scaling=True, reflection=True, reduction=False,
         Cutoff for 'small' singular values to regularize the
         inverse. See :class:`~numpy.linalg.lstsq` for more
         information.
+
+    normalize : str or False
+        If set to 'across', the columns of the input data will be z-scored
+        across lists (default). If set to 'within', the columns will be
+        z-scored within each list that is passed. If set to 'row', each row of
+        the input data will be z-scored. If set to False, the input data will
+        be returned (default is False).
 
     ndims : int
         Number of dimensions to reduce the dataset to *prior* to alignment
@@ -194,6 +200,10 @@ def procrustes(source, target, scaling=True, reflection=True, reduction=False,
             res += _offset_out
 
         return res
+
+    # normalize data
+    if normalize:
+        x = normalizer(x, normalize=normalize)
 
     # reduce if ndims is specified
     if ndims is not None:

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -31,13 +31,11 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
         reduction models.
 
     normalize : str or False
-        Normalizes the data before reducing. If set to 'across', the columns
-        of the input data will be z-scored across lists (default). That is,
-        the z-scores will be computed with repect to column n across all arrays
-        passed in the list. If set to 'within', the columns will be z-scored
-        within each list that is passed. If set to 'row', each row of the
-        input data will be z-scored. If set to False, the input data will be
-        returned with no z-scoring.
+        If set to 'across', the columns of the input data will be z-scored
+        across lists (default). If set to 'within', the columns will be
+        z-scored within each list that is passed. If set to 'row', each row of
+        the input data will be z-scored. If set to False, the input data will
+        be returned (default is False).
 
     align : bool
         If set to True, data will be run through the ``hyperalignment''
@@ -102,6 +100,7 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
             x_reduced[idx] = np.hstack([x_r, np.zeros((x_r.shape[0], ndims-x_reduced[0].shape[1]))])
 
     if align == True:
+        # Import is here to avoid circular imports with reduce.py
         from .align import align as aligner
         x_reduced = aligner(x_reduced)
 

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -5,12 +5,13 @@ import warnings
 import numpy as np
 from .._externals.ppca import PPCA
 from sklearn.decomposition import PCA as PCA
-from ..tools.df2mat import df2mat
-from ..tools.normalize import normalize as normalizer
+from .df2mat import df2mat
+from .normalize import normalize as normalizer
 from .._shared.helpers import *
 
 ##MAIN FUNCTION##
-def reduce(x, ndims=3, method='PCA', normalize=False, internal=False):
+def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
+           align=False):
     """
     Reduces dimensionality of an array, or list of arrays
 
@@ -37,6 +38,10 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False):
         within each list that is passed. If set to 'row', each row of the
         input data will be z-scored. If set to False, the input data will be
         returned with no z-scoring.
+
+    align : bool
+        If set to True, data will be run through the ``hyperalignment''
+        algorithm implemented in hypertools.tools.align (default: False).
 
     Returns
     ----------
@@ -95,6 +100,10 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False):
     if x_reduced[0].shape[1] < ndims:
         for idx, x_r in enumerate(x_reduced):
             x_reduced[idx] = np.hstack([x_r, np.zeros((x_r.shape[0], ndims-x_reduced[0].shape[1]))])
+
+    if align == True:
+        from .align import align as aligner
+        x_reduced = aligner(x_reduced)
 
     if internal or len(x_reduced)>1:
         return x_reduced

--- a/tests/test_align.py
+++ b/tests/test_align.py
@@ -6,6 +6,8 @@ import numpy as np
 from hypertools.tools.align import align
 from hypertools.tools.load import load
 
+weights = load('weights')
+
 def test_procrustes():
     data1 = load('spiral')
     rot = np.array([[-0.89433495, -0.44719485, -0.01348182],
@@ -23,3 +25,13 @@ def test_srm():
     data2 = np.dot(data1, rot)
     result = align([data1,data2], method='SRM')
     assert np.allclose(result[0],result[1], rtol=1) #note: this tolerance is probably too high, but fails at anything lower
+
+def test_align_shapes():
+    # Should return data with the same shape as input data
+    aligned = align(weights)
+    assert all(al.shape == wt.shape for al, wt in zip(aligned, weights))
+
+def test_align_reduce5d_shape():
+    # Should return data with same rowcnt but reduced to 5 columns
+    aligned = align(weights, ndims=5)
+    assert all(al.shape == (wt.shape[0], 5) for al, wt in zip(aligned, weights))

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+
+from hypertools.tools.load import load
+
+def test_weights():
+    weights = load('weights')
+    assert all(wt.shape == (300, 100) for wt in weights)
+
+def test_weights_ndim3():
+    # Should return 3 dimensional data
+    weights = load('weights', ndims=3)
+    assert all(wt.shape == (300, 3) for wt in weights)
+
+def test_weights_ndim2():
+    # Should return 2 dimensional data
+    weights = load('weights', ndims=2)
+    assert all(wt.shape == (300, 2) for wt in weights)
+
+def test_weights_ndim1():
+    # Should return 1 dimensional data
+    weights = load('weights', ndims=1)
+    assert all(wt.shape == (300, 1) for wt in weights)
+
+def test_weights_ndim3_align():
+    # Should return aligned 3 dimensional data
+    weights = load('weights', ndims=3, align=True)
+    assert all(wt.shape == (300, 3) for wt in weights)
+
+def test_weights_ndim2_align():
+    # Should return aligned 2 dimensional data
+    weights = load('weights', ndims=2, align=True)
+    assert all(wt.shape == (300, 2) for wt in weights)
+
+def test_weights_ndim1_align():
+    # Should return aligned 1 dimensional data
+    weights = load('weights', ndims=1, align=True)
+    assert all(wt.shape == (300, 1) for wt in weights)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -38,9 +38,9 @@ def test_plot_3d():
     assert all([i.shape[1]==3 for i in data_3d])
 
 def test_plot_reduce_none():
-    # Should return 3d data if ndims is None
-    _, _, data_3d, _ = plot.plot(data, show=False)
-    assert all([i.shape[1] == 3 for i in data_3d])
+    # Should return same dimensional data if ndims is None
+    _, _, data_new, _ = plot.plot(data, show=False)
+    assert all([i.shape[1] == d.shape[1] for i, d in zip(data_new, data)])
 
 def test_plot_reduce3d():
     # should return 3d data since ndims=3
@@ -69,7 +69,7 @@ def test_plot_reduce10d():
 
 def test_plot_nd():
     _, _, data_nd, _  = plot.plot(data, show=False)
-    assert all([i.shape[1]==3 for i in data_nd])
+    assert all([i.shape[1]==d.shape[1] for i, d in zip(data_nd, data)])
 
 def test_plot_data_is_list():
     _, _, data_nd, _  = plot.plot(data, show=False)
@@ -102,7 +102,7 @@ def test_plot_3d_animate():
 
 def test_plot_nd_animate():
     _,_,data_nd,_ = plot.plot(data, animate=True, show=False)
-    assert all([i.shape[1]==3 for i in data_nd])
+    assert all([i.shape[1]==d.shape[1] for i, d in zip(data_nd, data)])
 
 def test_plot_data_animate_is_list():
     _,_,data_nd,_ = plot.plot(data, animate=True, show=False)
@@ -121,5 +121,5 @@ def test_plot_animate_check_line_ani():
     assert isinstance(line_ani,mpl.animation.FuncAnimation)
 
 def test_plot_mpl_kwargs():
-    _, _, data_3d, _  = plot.plot(data, colors=['b','r'], linestyles=['--',':'], markers=['o','*'], show=False)
-    assert all([i.shape[1]==3 for i in data_3d])
+    _, _, data_new, _  = plot.plot(data, colors=['b','r'], linestyles=['--',':'], markers=['o','*'], show=False)
+    assert all([i.shape[1]==d.shape[1] for i, d in zip(data_new, data)])

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -8,8 +8,14 @@ import matplotlib as mpl
 
 from hypertools.plot import plot
 from hypertools.tools.reduce import reduce as reduc
+from hypertools.tools.load import load
 
-data = [np.random.multivariate_normal(np.zeros(4), np.eye(4), size=100) for i in range(2)]
+data = [np.random.multivariate_normal(np.zeros(4), np.eye(4), size=100) for i
+        in range(2)]
+weights = load('weights')
+
+# To prevent warning about 20+ figs being open
+mpl.rcParams['figure.max_open_warning'] = 25
 
 ## STATIC ##
 def test_plot_1d():
@@ -30,6 +36,36 @@ def test_plot_3d():
     data_reduced_3d = reduc(data,ndims=3)
     _, _, data_3d, _  = plot.plot(data_reduced_3d, show=False)
     assert all([i.shape[1]==3 for i in data_3d])
+
+def test_plot_reduce_none():
+    # Should return 3d data if ndims is None
+    _, _, data_3d, _ = plot.plot(data, show=False)
+    assert all([i.shape[1] == 3 for i in data_3d])
+
+def test_plot_reduce3d():
+    # should return 3d data since ndims=3
+    _, _, data_3d, _ = plot.plot(data, ndims=3, show=False)
+    assert all([i.shape[1] == 3 for i in data_3d])
+    
+def test_plot_reduce2d():
+    # should return 2d data since ndims=2
+    _, _, data_2d, _ = plot.plot(data, ndims=2, show=False)
+    assert all([i.shape[1] == 2 for i in data_2d])
+
+def test_plot_reduce1d():
+    # should return 1d data since ndims=1
+    _, _, data_1d, _ = plot.plot(data, ndims=1, show=False)
+    assert all([i.shape[1] == 1 for i in data_1d])
+
+def test_plot_reduce_align5d():
+    # should return 5d data since ndims=5
+    _, _, weights_5d, _ = plot.plot(weights, ndims=5, align=True, show=False)
+    assert all([i.shape[1] == 5 for i in weights_5d])
+
+def test_plot_reduce10d():
+    # should return 10d data since ndims=10
+    _, _, weights_10d, _ = plot.plot(weights, ndims=10, show=False)
+    assert all([i.shape[1] == 10 for i in weights_10d])
 
 def test_plot_nd():
     _, _, data_nd, _  = plot.plot(data, show=False)

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -27,6 +27,21 @@ def test_reduce_dims_2d():
 def test_reduce_dims_1d():
     assert reduced_data_1d[0].shape==(100,1)
 
+def test_reduce_dims_3d_align():
+    # Should return aligned data that is reduced to 3 dims
+    reduced_aligned_data_3d = reduc(data, align=True)
+    assert all(rad.shape == (100, 3) for rad in reduced_aligned_data_3d)
+
+def test_reduce_dims_2d_align():
+    # Should return aligned data that is reduced to 2 dims
+    reduced_aligned_data_2d = reduc(data, ndims=2, align=True)
+    assert all(rad.shape == (100, 2) for rad in reduced_aligned_data_2d)
+
+def test_reduce_dims_1d_align():
+    # Should return aligned data that is reduced to 1 dim
+    reduced_aligned_data_1d = reduc(data, ndims=1, align=True)
+    assert all(rad.shape == (100, 1) for rad in reduced_aligned_data_1d)
+    
 def test_reduce_assert_exception():
     with pytest.raises(Exception) as e_info:
         reduc(data,ndims=4)


### PR DESCRIPTION
This PR implements the kw args `ndims` and `align` in some of the key hypertools functions, as was requested in Issue #105.

I was able to successfully run the tests using pytest and I had no issues running the following commands.

```python
hyp.tools.load('weights', ndims=3)
hyp.tools.load('weights', ndims=2)
hyp.tools.load('weights', ndims=1)
hyp.tools.load('weights', align=True)
hyp.tools.load('weights', ndims=3, align=True)
hyp.tools.load('weights', ndims=2, align=True)
hyp.tools.load('weights', ndims=1, align=True)
```

Let me know if there's anything that I can adjust.