### PR TITLE
Reduction models

### DIFF
--- a/examples/animate_MDS.py
+++ b/examples/animate_MDS.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+=============================
+Animated trajectory plotted with multidimensional scaling
+=============================
+
+This is a trajectory of brain data, hyperaligned and then plotted in 3D
+with multidimensional scaling.
+"""
+
+# Code source: Andrew Heusser
+# License: MIT
+
+import hypertools as hyp
+import scipy.io as sio
+import numpy as np
+
+data = hyp.tools.load('weights')
+aligned_w = hyp.tools.align(data)
+
+w1 = np.mean(aligned_w[:17],0)
+w2 = np.mean(aligned_w[18:],0)
+
+hyp.plot([w1, w2], animate=True, model='MDS')

--- a/examples/plot_TSNE.py
+++ b/examples/plot_TSNE.py
@@ -18,6 +18,6 @@ import hypertools as hyp
 
 digits = datasets.load_digits(n_class=6)
 data = digits.data
-group = digits.target
+group = digits.target.astype('str')
 
-hyp.plot(data, '.', model='TSNE', group=group, ndims=2, legend=True)
+hyp.plot(data, '.', model='TSNE', group=group, ndims=2)

--- a/examples/plot_TSNE.py
+++ b/examples/plot_TSNE.py
@@ -5,8 +5,7 @@ Visualizing the digits dataset using t-SNE
 =============================
 
 This example loads in some data from the scikit-learn digits dataset and plots
-it using t-SNE. Other supported models include PCA, FastICA, MDS, Isomap,
-SpectralEmbedding and LocallyLinearEmbedding
+it using t-SNE.
 
 """
 

--- a/examples/plot_TSNE.py
+++ b/examples/plot_TSNE.py
@@ -6,7 +6,6 @@ Visualizing the digits dataset using t-SNE
 
 This example loads in some data from the scikit-learn digits dataset and plots
 it using t-SNE.
-
 """
 
 # Code source: Andrew Heusser

--- a/examples/plot_TSNE.py
+++ b/examples/plot_TSNE.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+=============================
+Visualizing the digits dataset using t-SNE
+=============================
+
+This example loads in some data from the scikit-learn digits dataset and plots
+it using t-SNE. Other supported models include PCA, FastICA, MDS, Isomap,
+SpectralEmbedding and LocallyLinearEmbedding
+
+"""
+
+# Code source: Andrew Heusser
+# License: MIT
+
+from sklearn import datasets
+import hypertools as hyp
+
+digits = datasets.load_digits(n_class=6)
+data = digits.data
+group = digits.target
+
+hyp.plot(data, 'o', model='TSNE', group=group)

--- a/examples/plot_TSNE.py
+++ b/examples/plot_TSNE.py
@@ -20,4 +20,4 @@ digits = datasets.load_digits(n_class=6)
 data = digits.data
 group = digits.target
 
-hyp.plot(data, 'o', model='TSNE', group=group)
+hyp.plot(data, '.', model='TSNE', group=group, ndims=2, legend=True)

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -14,14 +14,14 @@ import matplotlib.pyplot as plt
 from .._shared.helpers import *
 from ..tools.cluster import cluster
 from ..tools.df2mat import df2mat
-from ..tools.reduce import reduce as reduceD
+from ..tools.reduce import reduce as reducer
 from ..tools.normalize import normalize as normalizer
 from ..tools.align import align as aligner
 from .draw import draw
 
 def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
          linestyles=None, color=None, colors=None, palette='hls', group=None,
-         labels=None, legend=None, title=None, elev=10, azim=-60, ndims=3,
+         labels=None, legend=None, title=None, elev=10, azim=-60, ndims=None,
          model='PCA', model_params={}, align=False, normalize=False, n_clusters=None,
          save_path=None, animate=False, duration=30, tail_duration=2,
          rotations=2, zoom=1, chemtrails=False, precog=False, bullettime=False,
@@ -180,7 +180,8 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # reduce data to ndims
     if ndims is not None:
-        x = reduceD(x, ndims=ndims, internal=True)
+        x = reducer(x, ndims=ndims, model=model, model_params=model_params,
+                    internal=True)
 
     # align data
     if align:
@@ -221,7 +222,7 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # reduce data to 3 dims for plotting, if ndims is None, return this
     if (ndims and ndims > 3) or (ndims is None and x[0].shape[1] > 3):
-        x = reduceD(x, ndims=3, model=model, model_params=model_params, internal=True)
+        x = reducer(x, ndims=3, model=model, model_params=model_params, internal=True)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -90,6 +90,17 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         If set to True, data will be run through the ``hyperalignment''
         algorithm implemented in hypertools.tools.align (default: False).
 
+    model : str
+        Reduction model to use.  Models supported: PCA, TSNE, MDS, Isomap,
+        SpectralEmbedding, LocallyLinearEmbedding, FastICA. See
+        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details.
+
+    model_params : dict
+        Optional dictionary to pass parameters to reduction model. See
+        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details.
+
     normalize : str or False
         If set to 'across', the columns of the input data will be z-scored
         across lists (default). If set to 'within', the columns will be

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -22,8 +22,8 @@ from .draw import draw
 def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
          linestyles=None, color=None, colors=None, palette='hls', group=None,
          labels=None, legend=None, title=None, elev=10, azim=-60, ndims=None,
-         model='PCA', model_params={}, align=False, normalize=False, n_clusters=None,
-         save_path=None, animate=False, duration=30, tail_duration=2,
+         model='IncrementalPCA', model_params={}, align=False, normalize=False,
+         n_clusters=None, save_path=None, animate=False, duration=30, tail_duration=2,
          rotations=2, zoom=1, chemtrails=False, precog=False, bullettime=False,
          frame_rate=50, explore=False, show=True):
     """

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -76,15 +76,14 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         kwargs.
 
     model : str
-        Reduction model to use.  Models supported: PCA, TSNE, MDS, Isomap,
-        SpectralEmbedding, LocallyLinearEmbedding, FastICA. See
-        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details.
+        Decomposition/manifold learning model to use.  Models supported: PCA,
+        IncrementalPCA, SparsePCA, MiniBatchSparsePCA, KernelPCA, FastICA,
+        FactorAnalysis, TruncatedSVD, DictionaryLearning, MiniBatchDictionaryLearning,
+        TSNE, Isomap, SpectralEmbedding, LocallyLinearEmbedding, and MDS.
 
     model_params : dict
-        Optional dictionary to pass parameters to reduction model. See
-        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details.
+        Optional dictionary of scikit-learn parameters to pass to reduction model.
+        See scikit-learn specific model docs for details.
 
     align : bool
         If set to True, data will be run through the ``hyperalignment''

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -75,6 +75,17 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
         possibly normalized and/or aligned according to normalize/align
         kwargs.
 
+    model : str
+        Reduction model to use.  Models supported: PCA, TSNE, MDS, Isomap,
+        SpectralEmbedding, LocallyLinearEmbedding, FastICA. See
+        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details.
+
+    model_params : dict
+        Optional dictionary to pass parameters to reduction model. See
+        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details.
+
     align : bool
         If set to True, data will be run through the ``hyperalignment''
         algorithm implemented in hypertools.tools.align (default: False).

--- a/hypertools/plot/plot.py
+++ b/hypertools/plot/plot.py
@@ -21,11 +21,11 @@ from .draw import draw
 
 def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
          linestyles=None, color=None, colors=None, palette='hls', group=None,
-         labels=None, legend=None, title=None, elev=10, azim=-60, ndims=None,
-         align=False, normalize=False, n_clusters=None, save_path=None,
-         animate=False, duration=30, tail_duration=2, rotations=2, zoom=1,
-         chemtrails=False, precog=False, bullettime=False, frame_rate=50,
-         explore=False, show=True):
+         labels=None, legend=None, title=None, elev=10, azim=-60, ndims=3,
+         model='PCA', model_params={}, align=False, normalize=False, n_clusters=None,
+         save_path=None, animate=False, duration=30, tail_duration=2,
+         rotations=2, zoom=1, chemtrails=False, precog=False, bullettime=False,
+         frame_rate=50, explore=False, show=True):
     """
     Plots dimensionality reduced data and parses plot arguments
 
@@ -89,17 +89,6 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
     align : bool
         If set to True, data will be run through the ``hyperalignment''
         algorithm implemented in hypertools.tools.align (default: False).
-
-    model : str
-        Reduction model to use.  Models supported: PCA, TSNE, MDS, Isomap,
-        SpectralEmbedding, LocallyLinearEmbedding, FastICA. See
-        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details.
-
-    model_params : dict
-        Optional dictionary to pass parameters to reduction model. See
-        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details.
 
     normalize : str or False
         If set to 'across', the columns of the input data will be z-scored
@@ -221,7 +210,7 @@ def plot(x, fmt=None, marker=None, markers=None, linestyle=None,
 
     # reduce data to 3 dims for plotting, if ndims is None, return this
     if (ndims and ndims > 3) or (ndims is None and x[0].shape[1] > 3):
-        x = reduceD(x, ndims=3, internal=True)
+        x = reduceD(x, ndims=3, model=model, model_params=model_params, internal=True)
 
     # find cluster and reshape if n_clusters
     if n_clusters is not None:

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -1,17 +1,21 @@
 #!/usr/bin/env python
 
-##PACKAGES##
+# libraries
 import warnings
 import numpy as np
+
+## reduction models
 from .._externals.ppca import PPCA
-from sklearn.decomposition import PCA as PCA
-from .df2mat import df2mat
-from .normalize import normalize as normalizer
+from sklearn.decomposition import PCA, FastICA
+from sklearn.manifold import TSNE, MDS, SpectralEmbedding, LocallyLinearEmbedding, Isomap
+
+# internal libraries
+from ..tools.df2mat import df2mat
+from ..tools.normalize import normalize as normalizer
 from .._shared.helpers import *
 
-##MAIN FUNCTION##
-def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
-           align=False):
+# main function
+def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=False):
     """
     Reduces dimensionality of an array, or list of arrays
 
@@ -25,10 +29,16 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
     ndims : int
         Number of dimensions to reduce
 
-    method : str
-        Reduction model to use.  Currently, only 'PCA' (PCA/PPCA) is
-        implemented. In next release this kwarg will support all scikit-learn
-        reduction models.
+    model : str
+        Decomposition/manifold learning model to use.  Models supported: PCA,
+        FastICA, TSNE, MDS, Isomap, SpectralEmbedding, and LocallyLinearEmbedding.
+        See http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details.
+
+    model_params : dict
+        Optional dictionary to pass parameters to model. See
+        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
+        for details of each model.
 
     normalize : str or False
         If set to 'across', the columns of the input data will be z-scored
@@ -49,55 +59,72 @@ def reduce(x, ndims=3, method='PCA', normalize=False, internal=False,
 
     """
 
-    ##SUB FUNCTIONS##
-    def reducePCA(x, ndim):
+    # sub functions
+    def fill_missing(x):
 
-        # if there are any nans in any of the lists, use ppca
-        if np.isnan(np.vstack(x)).any():
-            warnings.warn('Missing data: Inexact solution computed with PPCA (see https://github.com/allentran/pca-magic for details)')
+        # ppca if missing data
+        m = PPCA()
+        m.fit(data=np.vstack(x), d=ndim)
+        x_pca = m.transform()
 
-            # ppca if missing data
-            m = PPCA()
-            m.fit(data=np.vstack(x), d=ndim)
-            x_pca = m.transform()
+        # if the whole row is missing, return nans
+        all_missing = [idx for idx,a in enumerate(np.vstack(x)) if all([type(b)==np.nan for b in a])]
+        if len(all_missing)>0:
+            for i in all_missing:
+                x_pca[i,:]=np.nan
 
-            # if the whole row is missing, return nans
-            all_missing = [idx for idx,a in enumerate(np.vstack(x)) if all([type(b)==np.nan for b in a])]
-            if len(all_missing)>0:
-                for i in all_missing:
-                    x_pca[i,:]=np.nan
-
-            # get the original lists back
-            if len(x)>1:
-                x_split = np.cumsum([i.shape[0] for i in x][:-1])
-                return list(np.split(x_pca,x_split,axis=0))
-            else:
-                return [x_pca]
-
+        # get the original lists back
+        if len(x)>1:
+            x_split = np.cumsum([i.shape[0] for i in x][:-1])
+            return list(np.split(x_pca,x_split,axis=0))
         else:
-            m=PCA(n_components=ndim, whiten=True)
-            m.fit(np.vstack(x))
-            if len(x)>1:
-                return [m.transform(i) for i in x]
-            else:
-                return [m.transform(x[0])]
+            return [x_pca]
 
+    def reduce_list(x, model, model_params):
+        split = np.cumsum([len(xi) for xi in x])[:-1]
+        m=model(**model_params)
+        x_r = np.vsplit(m.fit_transform(np.vstack(x)), split)
+        if len(x)>1:
+            return [xi for xi in x_r]
+        else:
+            return [x_r[0]]
+
+    # dictionary of models
+    models = {
+        'PCA' : PCA,
+        'FastICA' : FastICA,
+        'TSNE' : TSNE,
+        'Isomap' : Isomap,
+        'SpectralEmbedding' : SpectralEmbedding,
+        'LocallyLinearEmbedding' : LocallyLinearEmbedding
+    }
+
+    # main
     x = format_data(x)
 
     assert all([i.shape[1]>ndims for i in x]), "In order to reduce the data, ndims must be less than the number of dimensions"
 
-    # normalize data
+    # if there are any nans in any of the lists, use ppca
+    if np.isnan(np.vstack(x)).any():
+        warnings.warn('Missing data: Inexact solution computed with PPCA (see https://github.com/allentran/pca-magic for details)')
+        x = fill_missing(x)
+
+    # normalize
     if normalize:
         x = normalizer(x, normalize=normalize)
 
-    # run the reduction
-    if method=='PCA':
-        x_reduced = reducePCA(x,ndims)
+    # build model params dict
+    if model_params=={}:
+        model_params = {
+            'n_components' : ndims
+        }
+    elif 'n_components' in model_params:
+        pass
+    else:
+        model_params['n_components']=ndims
 
-    # pad cols with zeros if ndims returned is less than ndims
-    if x_reduced[0].shape[1] < ndims:
-        for idx, x_r in enumerate(x_reduced):
-            x_reduced[idx] = np.hstack([x_r, np.zeros((x_r.shape[0], ndims-x_reduced[0].shape[1]))])
+    # reduce data
+    x_reduced = reduce_list(x, models[model], model_params)
 
     if align == True:
         # Import is here to avoid circular imports with reduce.py

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -15,7 +15,7 @@ from ..tools.normalize import normalize as normalizer
 from .._shared.helpers import *
 
 # main function
-def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=False,
+def reduce(x, ndims=3, model='IncrementalPCA', model_params={}, normalize=False, internal=False,
            align=False):
     """
     Reduces dimensionality of an array, or list of arrays

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -96,7 +96,8 @@ def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=F
         'TSNE' : TSNE,
         'Isomap' : Isomap,
         'SpectralEmbedding' : SpectralEmbedding,
-        'LocallyLinearEmbedding' : LocallyLinearEmbedding
+        'LocallyLinearEmbedding' : LocallyLinearEmbedding,
+        'MDS' : MDS
     }
 
     # main

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -6,7 +6,7 @@ import numpy as np
 
 ## reduction models
 from .._externals.ppca import PPCA
-from sklearn.decomposition import PCA, FastICA
+from sklearn.decomposition import PCA, FastICA, IncrementalPCA, ProjectedGradientNMF, KernelPCA, FactorAnalysis, TruncatedSVD, NMF, SparsePCA, MiniBatchSparsePCA, DictionaryLearning, MiniBatchDictionaryLearning
 from sklearn.manifold import TSNE, MDS, SpectralEmbedding, LocallyLinearEmbedding, Isomap
 
 # internal libraries
@@ -92,7 +92,17 @@ def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=F
     # dictionary of models
     models = {
         'PCA' : PCA,
+        'IncrementalPCA' : IncrementalPCA,
+        'SparsePCA' : SparsePCA,
+        'MiniBatchSparsePCA' : MiniBatchSparsePCA,
+        'KernelPCA' : KernelPCA,
         'FastICA' : FastICA,
+        'NMF' : NMF,
+        'ProjectedGradientNMF' : ProjectedGradientNMF,
+        'FactorAnalysis' : FactorAnalysis,
+        'TruncatedSVD' : TruncatedSVD,
+        'DictionaryLearning' : DictionaryLearning,
+        'MiniBatchDictionaryLearning' : MiniBatchDictionaryLearning,
         'TSNE' : TSNE,
         'Isomap' : Isomap,
         'SpectralEmbedding' : SpectralEmbedding,

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -15,7 +15,8 @@ from ..tools.normalize import normalize as normalizer
 from .._shared.helpers import *
 
 # main function
-def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=False):
+def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=False,
+           align=False):
     """
     Reduces dimensionality of an array, or list of arrays
 

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -32,14 +32,13 @@ def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=F
 
     model : str
         Decomposition/manifold learning model to use.  Models supported: PCA,
-        FastICA, TSNE, MDS, Isomap, SpectralEmbedding, and LocallyLinearEmbedding.
-        See http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details.
+        IncrementalPCA, SparsePCA, MiniBatchSparsePCA, KernelPCA, FastICA,
+        FactorAnalysis, TruncatedSVD, DictionaryLearning, MiniBatchDictionaryLearning,
+        TSNE, Isomap, SpectralEmbedding, LocallyLinearEmbedding, and MDS.
 
     model_params : dict
-        Optional dictionary to pass parameters to model. See
-        http://scikit-learn.org/stable/modules/classes.html#module-sklearn.manifold
-        for details of each model.
+        Optional dictionary of scikit-learn parameters to pass to reduction model.
+        See scikit-learn specific model docs for details.
 
     normalize : str or False
         If set to 'across', the columns of the input data will be z-scored

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -6,7 +6,7 @@ import numpy as np
 
 ## reduction models
 from .._externals.ppca import PPCA
-from sklearn.decomposition import PCA, FastICA, IncrementalPCA, ProjectedGradientNMF, KernelPCA, FactorAnalysis, TruncatedSVD, NMF, SparsePCA, MiniBatchSparsePCA, DictionaryLearning, MiniBatchDictionaryLearning
+from sklearn.decomposition import PCA, FastICA, IncrementalPCA, KernelPCA, FactorAnalysis, TruncatedSVD, SparsePCA, MiniBatchSparsePCA, DictionaryLearning, MiniBatchDictionaryLearning
 from sklearn.manifold import TSNE, MDS, SpectralEmbedding, LocallyLinearEmbedding, Isomap
 
 # internal libraries
@@ -97,8 +97,6 @@ def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=F
         'MiniBatchSparsePCA' : MiniBatchSparsePCA,
         'KernelPCA' : KernelPCA,
         'FastICA' : FastICA,
-        'NMF' : NMF,
-        'ProjectedGradientNMF' : ProjectedGradientNMF,
         'FactorAnalysis' : FactorAnalysis,
         'TruncatedSVD' : TruncatedSVD,
         'DictionaryLearning' : DictionaryLearning,

--- a/hypertools/tools/reduce.py
+++ b/hypertools/tools/reduce.py
@@ -131,6 +131,7 @@ def reduce(x, ndims=3, model='PCA', model_params={}, normalize=False, internal=F
         from .align import align as aligner
         x_reduced = aligner(x_reduced)
 
+    # return data
     if internal or len(x_reduced)>1:
         return x_reduced
     else:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib as mpl
 
 from hypertools.plot import plot
-from hypertools.tools.reduce import reduce as reduc
+from hypertools.tools.reduce import reduce as reducer
 from hypertools.tools.load import load
 
 data = [np.random.multivariate_normal(np.zeros(4), np.eye(4), size=100) for i
@@ -19,7 +19,7 @@ mpl.rcParams['figure.max_open_warning'] = 25
 
 ## STATIC ##
 def test_plot_1d():
-    data_reduced_1d = reduc(data,ndims=1)
+    data_reduced_1d = reducer(data,ndims=1)
     _, _, data_1d, _ = plot.plot(data_reduced_1d, show=False)
     assert all([i.shape[1]==1 for i in data_1d])
 
@@ -28,12 +28,12 @@ def test_plot_1dim():
     assert data_1dim[0].ndim==2
 
 def test_plot_2d():
-    data_reduced_2d = reduc(data,ndims=2)
+    data_reduced_2d = reducer(data,ndims=2)
     _, _, data_2d, _  = plot.plot(data_reduced_2d, show=False)
     assert all([i.shape[1]==2 for i in data_2d])
 
 def test_plot_3d():
-    data_reduced_3d = reduc(data,ndims=3)
+    data_reduced_3d = reducer(data,ndims=3)
     _, _, data_3d, _  = plot.plot(data_reduced_3d, show=False)
     assert all([i.shape[1]==3 for i in data_3d])
 
@@ -46,7 +46,7 @@ def test_plot_reduce3d():
     # should return 3d data since ndims=3
     _, _, data_3d, _ = plot.plot(data, ndims=3, show=False)
     assert all([i.shape[1] == 3 for i in data_3d])
-    
+
 def test_plot_reduce2d():
     # should return 2d data since ndims=2
     _, _, data_2d, _ = plot.plot(data, ndims=2, show=False)
@@ -86,17 +86,17 @@ def test_plot_check_ax():
 ## ANIMATED ##
 
 def test_plot_1d_animate():
-    data_reduced_1d = reduc(data,ndims=1)
+    data_reduced_1d = reducer(data,ndims=1)
     with pytest.raises(Exception) as e_info:
         plot.plot(data_reduced_1d, animate=True, show=False)
 
 def test_plot_2d_animate():
-    data_reduced_2d = reduc(data,ndims=2)
+    data_reduced_2d = reducer(data,ndims=2)
     with pytest.raises(Exception) as e_info:
         plot.plot(data_reduced_2d, animate=True, show=False)
 
 def test_plot_3d_animate():
-    data_reduced_3d = reduc(data,ndims=3)
+    data_reduced_3d = reducer(data,ndims=3)
     _,_,data_3d,_ = plot.plot(data_reduced_3d, animate=True, show=False)
     assert all([i.shape[1]==3 for i in data_3d])
 
@@ -122,4 +122,5 @@ def test_plot_animate_check_line_ani():
 
 def test_plot_mpl_kwargs():
     _, _, data_new, _  = plot.plot(data, colors=['b','r'], linestyles=['--',':'], markers=['o','*'], show=False)
+    print([i.shape for i in data_new], [i.shape for i in data])
     assert all([i.shape[1]==d.shape[1] for i, d in zip(data_new, data)])

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -75,10 +75,6 @@ def test_reduce_FastICA():
     reduced_data_3d = reducer(data, model='FastICA', ndims=3)
     assert reduced_data_3d[0].shape==(100,3)
 
-# def test_reduce_NMF():
-#     reduced_data_3d = reducer(np.abs(data), model='NMF', ndims=3)
-#     assert reduced_data_3d[0].shape==(100,3)
-
 def test_reduce_FactorAnalysis():
     reduced_data_3d = reducer(data, model='FactorAnalysis', ndims=3)
     assert reduced_data_3d[0].shape==(100,3)

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -4,27 +4,32 @@ from builtins import range
 import pytest
 
 import numpy as np
+import scipy
 
-from hypertools.tools.reduce import reduce as reduc
+from hypertools.tools.reduce import reduce as reducer
 
 data = [np.random.multivariate_normal(np.zeros(4), np.eye(4), size=100) for i in range(2)]
-reduced_data_3d = reduc(data)
-reduced_data_2d = reduc(data,ndims=2)
-reduced_data_1d = reduc(data,ndims=1)
+reduced_data_2d = reducer(data,ndims=2)
+reduced_data_1d = reducer(data,ndims=1)
 
 def test_reduce_is_list():
+    reduced_data_3d = reducer(data)
     assert type(reduced_data_3d) is list
 
 def test_reduce_is_array():
+    reduced_data_3d = reducer(data, ndims=3)
     assert isinstance(reduced_data_3d[0],np.ndarray)
 
 def test_reduce_dims_3d():
+    reduced_data_3d = reducer(data, ndims=3)
     assert reduced_data_3d[0].shape==(100,3)
 
 def test_reduce_dims_2d():
+    reduced_data_2d = reducer(data, ndims=2)
     assert reduced_data_2d[0].shape==(100,2)
 
 def test_reduce_dims_1d():
+    reduced_data_1d = reducer(data, ndims=1)
     assert reduced_data_1d[0].shape==(100,1)
 
 def test_reduce_dims_3d_align():
@@ -45,3 +50,67 @@ def test_reduce_dims_1d_align():
 def test_reduce_assert_exception():
     with pytest.raises(Exception) as e_info:
         reduc(data,ndims=4)
+
+def test_reduce_PCA():
+    reduced_data_3d = reducer(data, model='PCA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_IncrementalPCA():
+    reduced_data_3d = reducer(data, model='IncrementalPCA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_SparsePCA():
+    reduced_data_3d = reducer(data, model='SparsePCA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_MiniBatchSparsePCA():
+    reduced_data_3d = reducer(data, model='MiniBatchSparsePCA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_KernelPCA():
+    reduced_data_3d = reducer(data, model='KernelPCA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_FastICA():
+    reduced_data_3d = reducer(data, model='FastICA', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+# def test_reduce_NMF():
+#     reduced_data_3d = reducer(np.abs(data), model='NMF', ndims=3)
+#     assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_FactorAnalysis():
+    reduced_data_3d = reducer(data, model='FactorAnalysis', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_TruncatedSVD():
+    reduced_data_3d = reducer(data, model='TruncatedSVD', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_DictionaryLearning():
+    reduced_data_3d = reducer(data, model='DictionaryLearning', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_MiniBatchDictionaryLearning():
+    reduced_data_3d = reducer(data, model='MiniBatchDictionaryLearning', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_TSNE():
+    reduced_data_3d = reducer(data, model='TSNE', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_Isomap():
+    reduced_data_3d = reducer(data, model='Isomap', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_SpectralEmbedding():
+    reduced_data_3d = reducer(data, model='SpectralEmbedding', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_LocallyLinearEmbedding():
+    reduced_data_3d = reducer(data, model='LocallyLinearEmbedding', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)
+
+def test_reduce_MDS():
+    reduced_data_3d = reducer(data, model='MDS', ndims=3)
+    assert reduced_data_3d[0].shape==(100,3)

--- a/tests/test_reduce.py
+++ b/tests/test_reduce.py
@@ -34,17 +34,17 @@ def test_reduce_dims_1d():
 
 def test_reduce_dims_3d_align():
     # Should return aligned data that is reduced to 3 dims
-    reduced_aligned_data_3d = reduc(data, align=True)
+    reduced_aligned_data_3d = reducer(data, align=True)
     assert all(rad.shape == (100, 3) for rad in reduced_aligned_data_3d)
 
 def test_reduce_dims_2d_align():
     # Should return aligned data that is reduced to 2 dims
-    reduced_aligned_data_2d = reduc(data, ndims=2, align=True)
+    reduced_aligned_data_2d = reducer(data, ndims=2, align=True)
     assert all(rad.shape == (100, 2) for rad in reduced_aligned_data_2d)
 
 def test_reduce_dims_1d_align():
     # Should return aligned data that is reduced to 1 dim
-    reduced_aligned_data_1d = reduc(data, ndims=1, align=True)
+    reduced_aligned_data_1d = reducer(data, ndims=1, align=True)
     assert all(rad.shape == (100, 1) for rad in reduced_aligned_data_1d)
     
 def test_reduce_assert_exception():


### PR DESCRIPTION
This PR extends hypertools to support the following dimensionality reduction / manifold learning models:

+ PCA
+ FastICA
+ IncrementalPCA
+ KernelPCA
+ FactorAnalysis
+ TruncatedSVD
+ SparsePCA
+ MiniBatchSparsePCA
+ DictionaryLearning
+ MiniBatchDictionaryLearning
+ TSNE
+ MDS
+ SpectralEmbedding
+ LocallyLinearEmbedding
+ Isomap

The default is PCA, but can be changed to any of the above like so:

```
hyp.plot(data, model='TSNE')
#or
reduced_data = hyp.tools.reduce(data, model='TSNE')
```

Additionally, you can specify model parameters via the `model_params` arg:

```
model_params = {'perplexity' : 40}
hyp.plot(data, model='TSNE', model_params=model_params)
```