### PR TITLE
Remove hdbscan dependency

### DIFF
--- a/examples/animate.py
+++ b/examples/animate.py
@@ -18,4 +18,4 @@ import hypertools as hyp
 geo = hyp.load('weights_avg')
 
 # plot
-geo.plot(animate=True)
+geo.plot(animate=True, legend=['first', 'second'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ matplotlib>=1.5.1
 scipy>=1.0.0
 numpy>=1.10.4
 umap-learn>=0.1.5
-hdbscan>=0.8.11
 future
 requests
 deepdish

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ LICENSE = 'MIT'
 
 setup(
     name='hypertools',
-    version='0.5.0',
+    version='0.5.1',
     description=DESCRIPTION,
     long_description=LONG_DESCRIPTION,
     author='Contextual Dynamics Lab',
@@ -42,7 +42,6 @@ setup(
    'matplotlib>=1.5.1',
    'scipy>=1.0.0',
    'numpy>=1.10.4',
-   'hdbscan>=0.8.11',
    'umap-learn>=0.1.5',
    'future',
    'requests',

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pytest
 from hypertools.tools.cluster import cluster
 from hypertools.plot.plot import plot
 
 cluster1 = np.random.multivariate_normal(np.zeros(3), np.eye(3), size=100)
 cluster2 = np.random.multivariate_normal(np.zeros(3)+100, np.eye(3), size=100)
-data = np.vstack([cluster1,cluster2])
-labels = cluster(data,n_clusters=2)
+data = np.vstack([cluster1, cluster2])
+labels = cluster(data, n_clusters=2)
 
 
 def test_cluster_n_clusters():
@@ -19,12 +20,15 @@ def test_cluster_returns_list():
 
 
 def test_cluster_hdbscan():
-    # Given well separated clusters this should "just work"
-    hdbscan_labels = cluster(data, cluster='HDBSCAN')
-    assert len(set(hdbscan_labels)) == 2
+    try:
+        from hdbscan import HDBSCAN
+        _has_hdbscan = True
+    except:
+        _has_hdbscan = False
 
-
-def text_cluster_geo():
-    geo = plot(data, show=False)
-    hdbscan_labels = cluster(geo, cluster='HDBSCAN')
-    assert len(set(hdbscan_labels)) == 2
+    if _has_hdbscan:
+        hdbscan_labels = cluster(data, cluster='HDBSCAN')
+        assert len(set(hdbscan_labels)) == 2
+    else:
+        with pytest.raises(ImportError):
+            hdbscan_labels = cluster(data, cluster='HDBSCAN')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -99,13 +99,6 @@ def test_plot_cluster_n_clusters():
     geo = plot.plot(weights, n_clusters=3, show=False)
     assert isinstance(geo, DataGeometry)
 
-
-def test_plot_cluster_HDBSCAN():
-    # should return 10d data since ndims=10
-    geo = plot.plot(weights, cluster='HDBSCAN', show=False)
-    assert isinstance(geo, DataGeometry)
-
-
 def test_plot_nd():
     geo  = plot.plot(data, show=False)
     assert all([i.shape[1]==d.shape[1] for i, d in zip(geo.data, data)])


### PR DESCRIPTION
This PR removes dependency on `hdbscan`. For some users (conda and maybe more), installation fails when installing `hdbscan` (see #195).   If `hdbscan` is already installed (manually), it will continue to work. If it is not installed (but called in `cluster` or `plot`) an `ImportError` is thrown. This should allow `hypertools` to be installable for a larger user base and still support `hdbscan`.