### PR TITLE
updated doc requirements

### DIFF
--- a/docs/doc_requirements.txt
+++ b/docs/doc_requirements.txt
@@ -1,5 +1,5 @@
-sphinx==1.5.5
-sphinx_bootstrap_theme==0.4.13
+sphinx==2.3.0
+sphinx_bootstrap_theme==0.6.4
 sphinx-gallery
 numpydoc
 deepdish


### PR DESCRIPTION
pinned sphinx requirements were set to work with a Python 2.7-based build.  Updated them to the versions I used to compile them locally