### PR TITLE
support more recent scikit-learn version and add tests for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 python:
 - '3.6'
 - '3.7'
+- '3.8'
 services:
   - xvfb
 install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PPCA>=0.0.2
-scikit-learn>=0.19.1,<0.22
+scikit-learn>=0.19.1,!=0.22
 pandas>=0.18.0
 seaborn>=0.8.1
 matplotlib>=1.5.1


### PR DESCRIPTION
We pinned `scikit-learn>=0.19.1,<0.22` a while back because v0.22 had something wrong with how the vocabulary for the CountVectorizer class was created.  This has been fixed in v0.23, so I've widened the requirements to allow for it.

I also added a travis test build for Python 3.8.