### PR TITLE
docs: fix simple typo, inialize -> initialize

### DIFF
--- a/hypertools/plot/draw.py
+++ b/hypertools/plot/draw.py
@@ -336,7 +336,7 @@ def _draw(x, legend=None, title=None, labels=False,
     def animate_plot3D(x, tail_duration=2, rotations=2, zoom=1, chemtrails=False,
                        frame_rate=50, elev=10, style='parallel'):
 
-        # inialize plot
+        # initialize plot
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
 


### PR DESCRIPTION
There is a small typo in hypertools/plot/draw.py.

Should read `initialize` rather than `inialize`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md