### PR TITLE
fix __version__ attr

### DIFF
--- a/hypertools/config.py
+++ b/hypertools/config.py
@@ -1,4 +1,4 @@
 from pkg_resources import get_distribution
 
 
-__version__ = get_distribution('hypertools')
+__version__ = get_distribution('hypertools').version


### PR DESCRIPTION
output the version string directly, rather than the `pkg_resources.DistInfoDistribution` object