### PR TITLE
Clarify DataGeometry initialization docs

### DIFF
--- a/docs/tutorials/geo.ipynb
+++ b/docs/tutorials/geo.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The DataGeometry object is the hypertools data object class. A `geo` contains the data, figure handles, and transform functions used to create a plot. Note that this class should not be called directly, but is used by the hyp.plot function to create a plot object.\n",
+    "The DataGeometry object is the hypertools data object class. A `geo` contains the data, figure handles, and transform functions used to create a plot. Note that new instances of this class should not be initialized directly, but are created by the hyp.plot function.\n",
     "\n",
     "In this tutorial we will explore the features of a geo and how it may be used."
    ]

--- a/docs/tutorials/geo.rst
+++ b/docs/tutorials/geo.rst
@@ -4,8 +4,8 @@ DataGeometry objects (``geo``)
 
 The DataGeometry object is the hypertools data object class. A ``geo``
 contains the data, figure handles, and transform functions used to
-create a plot. Note that this class should not be called directly, but
-is used by the hyp.plot function to create a plot object.
+create a plot. Note that new instances of this class should not be
+initialized directly, but are created by the hyp.plot function.
 
 In this tutorial we will explore the features of a geo and how it may be
 used.

--- a/hypertools/datageometry.py
+++ b/hypertools/datageometry.py
@@ -17,8 +17,8 @@ class DataGeometry(object):
     Hypertools data object class
 
     A DataGeometry object contains the data, figure handles and transform
-    functions used to create a plot.  Note: this class should not be called
-    directly, but is used by the `hyp.plot` function to create a plot object.
+    functions used to create a plot.  Note: new instances of this class should
+    not be initialized directly, but are created by the `hyp.plot` function.
 
     Parameters
     ----------


### PR DESCRIPTION
###Summary
- Clarifies the `DataGeometry` docs to say that new instances should not be initialized directly.
- Updates the same wording in the geo tutorial `.rst` and notebook source.

###Related issue
Addresses part of ContextLab/hypertools#159

###Checks
- python3 -m py_compile hypertools/datageometry.py
- python3 -m json.tool docs/tutorials/geo.ipynb
- git diff-check

Note that new instances of this class should not be initialized directly, but are created by the hyp.plot function.